### PR TITLE
Replace ssh git clone with https clone for better user experience

### DIFF
--- a/scripts/installation/conda_env/build.sh
+++ b/scripts/installation/conda_env/build.sh
@@ -8,7 +8,7 @@ conda activate naruto
 
 # ### Setup habitat-sim ###
 cd ${ROOT}/third_parties
-git clone git@github.com:Huangying-Zhan/habitat-sim.git habitat_sim
+git clone https://github.com/Huangying-Zhan/habitat-sim.git habitat_sim
 cd habitat_sim
 pip install -r requirements.txt
 python setup.py install --headless --bullet


### PR DESCRIPTION
In `scripts/installation/conda_env/build.sh`, SSH clone is used like `git clone git@github.com:Huangying-Zhan/habitat-sim.git habitat_sim`.  
The SSH clone method requires a `ssh-keygen` and uploading it to github before. But most users won't config it and they'll fail to execute the `build.sh`. 
The HTTPS clone doesn't have this issue and should provide a better user experience

This is tested with a brand new install ubuntu in docker:
```text
root@97691c0398bc:/# git clone git@github.com:Huangying-Zhan/habitat-sim.git habitat_sim
Cloning into 'habitat_sim'...
The authenticity of host 'github.com (20.205.243.166)' can't be established.
ED25519 key fingerprint is SHA256:+DiY3wvvV6TuJJhbpZisF/zLDA0zPMSvHdkr4UvCOqU.
This key is not known by any other names
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Warning: Permanently added 'github.com' (ED25519) to the list of known hosts.
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
root@97691c0398bc:/# git clone https://github.com/Huangying-Zhan/habitat-sim.git habitat_sim
Cloning into 'habitat_sim'...
remote: Enumerating objects: 18499, done.
remote: Total 18499 (delta 0), reused 0 (delta 0), pack-reused 18499 (from 1)
Receiving objects: 100% (18499/18499), 63.59 MiB | 7.24 MiB/s, done.
Resolving deltas: 100% (13956/13956), done.
```